### PR TITLE
Fix `npm publish` failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     - run: npm install
     - run: npm test
     - run: npm run build
-    - run: npm publish
+    - run: npm publish --access=public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   image:


### PR DESCRIPTION
I need to provide --access=public to the initial publication to publish
a scoped package.